### PR TITLE
Update django to 2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.0.8
+Django==2.1.7
 celery==4.2.1
 django-authtools==1.6.0
 django-celery-beat==1.1.1
@@ -6,7 +6,7 @@ django-cors-headers==2.4.0
 django-debug-toolbar==1.11
 django-environ==0.4.5
 django-eth-events==3.1.7
-django-filter==1.1.0
+django-filter==2.1.0
 django-model-utils==3.1.2
 django-rest-swagger==2.2.0
 django-solo==1.1.3

--- a/tradingdb/restapi/filters.py
+++ b/tradingdb/restapi/filters.py
@@ -123,10 +123,10 @@ class MarketTradesFilter(filters.FilterSet):
 
     def __init__(self, data=None, *args, **kwargs):
         # if filterset is bound, use initial values as defaults
-        if data is not None and not 'creation_date_time_0' in data and not 'creation_date_time_1' in data:
+        if data is not None and not 'creation_date_time_after' in data and not 'creation_date_time_before' in data:
             data = data.copy()
-            data['creation_date_time_0'] = (timezone.now() - timedelta(days=14)).strftime('%Y-%m-%d %H:%M:%S')
-            data['creation_date_time_1'] = timezone.now()
+            data['creation_date_time_after'] = (timezone.now() - timedelta(days=14)).strftime('%Y-%m-%d %H:%M:%S')
+            data['creation_date_time_before'] = timezone.now()
 
         super().__init__(data, *args, **kwargs)
 

--- a/tradingdb/restapi/tests/test_views.py
+++ b/tradingdb/restapi/tests/test_views.py
@@ -116,11 +116,11 @@ class TestViews(APITestCase):
         market = MarketFactory(event=event)
         from_date = (timezone.now() - timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
 
-        url = reverse('api:markets') + '?resolution_date_time_0=' + from_date
+        url = reverse('api:markets') + '?resolution_date_time_after=' + from_date
         correct_date_time_range_response = self.client.get(url, content_type='application/json')
         self.assertEqual(len(correct_date_time_range_response.json().get('results')), 1)
 
-        url = reverse('api:markets') + '?resolution_date_time_0=' + from_date + '&resolution_date_time_1=' + from_date
+        url = reverse('api:markets') + '?resolution_date_time_after=' + from_date + '&resolution_date_time_before=' + from_date
         empty_date_time_range_response = self.client.get(url, content_type='application/json')
         self.assertEqual(len(empty_date_time_range_response.json().get('results')), 0)
 
@@ -278,7 +278,7 @@ class TestViews(APITestCase):
         to_date = (creation_date_time + timedelta(days=1)).strftime('%Y-%m-%d %H:%M:%S')
         url = reverse('api:trades-by-market',
                       kwargs={'market_address': market.address})
-        url += '?creation_date_time_0=' + from_date + '&creation_date_time_1='+to_date
+        url += '?creation_date_time_after=' + from_date + '&creation_date_time_before='+to_date
         trades_response = self.client.get(url, content_type='application/json')
         self.assertEqual(trades_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(trades_response.json().get('results')), 1)
@@ -288,7 +288,7 @@ class TestViews(APITestCase):
         to_date = (creation_date_time - timedelta(days=4)).strftime('%Y-%m-%d %H:%M:%S')
         url = reverse('api:trades-by-market',
                       kwargs={'market_address': market.address})
-        url += '?creation_date_time_0=' + from_date + '&creation_date_time_1=' + to_date
+        url += '?creation_date_time_after=' + from_date + '&creation_date_time_before=' + to_date
         trades_response = self.client.get(url, content_type='application/json')
         self.assertEqual(trades_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(trades_response.json().get('results')), 0)
@@ -297,7 +297,7 @@ class TestViews(APITestCase):
         from_date = (creation_date_time - timedelta(days=5)).strftime('%Y-%m-%d %H:%M:%S')
         url = reverse('api:trades-by-market',
                       kwargs={'market_address': market.address})
-        url += '?creation_date_time_0=' + from_date
+        url += '?creation_date_time_after=' + from_date
         trades_response = self.client.get(url, content_type='application/json')
         self.assertEqual(trades_response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(trades_response.json().get('results')), 1)

--- a/tradingdb/restapi/views.py
+++ b/tradingdb/restapi/views.py
@@ -64,7 +64,7 @@ class AboutView(APIView):
 
 class CentralizedOracleListView(generics.ListAPIView):
     serializer_class = CentralizedOracleSerializer
-    filter_class = CentralizedOracleFilter
+    filterset_class = CentralizedOracleFilter
     pagination_class = DefaultPagination
 
     def get_queryset(self):
@@ -86,7 +86,7 @@ class CentralizedOracleFetchView(generics.RetrieveAPIView):
 
 class EventListView(generics.ListAPIView):
     serializer_class = EventSerializer
-    filter_class = EventFilter
+    filterset_class = EventFilter
     pagination_class = DefaultPagination
 
     def get_queryset(self):
@@ -122,7 +122,7 @@ class EventFetchView(generics.RetrieveAPIView):
 
 class MarketListView(generics.ListAPIView):
     serializer_class = MarketSerializer
-    filter_class = MarketFilter
+    filterset_class = MarketFilter
     pagination_class = DefaultPagination
 
     def get_queryset(self):
@@ -228,7 +228,7 @@ class AllMarketSharesView(generics.ListAPIView):
 class MarketParticipantTradesView(generics.ListAPIView):
     serializer_class = MarketTradesSerializer
     pagination_class = DefaultPagination
-    filter_class = MarketTradesFilter
+    filterset_class = MarketTradesFilter
 
     def get_queryset(self):
         return Order.objects.filter(
@@ -251,7 +251,7 @@ class MarketTradesView(generics.ListAPIView):
     """
     serializer_class = MarketTradesSerializer
     pagination_class = DefaultPagination
-    filter_class = MarketTradesFilter
+    filterset_class = MarketTradesFilter
 
     def get_queryset(self):
         # Check if Market exists
@@ -277,7 +277,7 @@ class AccountTradesView(generics.ListAPIView):
     """
     serializer_class = MarketTradesSerializer
     pagination_class = DefaultPagination
-    filter_class = MarketTradesFilter
+    filterset_class = MarketTradesFilter
 
     def get_queryset(self):
         return Order.objects.filter(
@@ -299,7 +299,7 @@ class AccountSharesView(generics.ListAPIView):
     """
     serializer_class = OutcomeTokenBalanceSerializer
     pagination_class = DefaultPagination
-    filter_class = MarketSharesFilter
+    filterset_class = MarketSharesFilter
 
     def get_queryset(self):
         return OutcomeTokenBalance.objects.filter(


### PR DESCRIPTION
- Updated django filters
- Filters using DateTimeFromToRangeFilter now using `_after` and `_before`
  instead of `_0` and `_1`

It address #92