### PR TITLE
Bug/pm 46 markets api

### DIFF
--- a/tradingdb/restapi/exceptions.py
+++ b/tradingdb/restapi/exceptions.py
@@ -1,0 +1,7 @@
+from rest_framework.exceptions import APIException, status
+
+
+class InvalidEthereumAddressForFilter(APIException):
+    def __init__(self, detail, code=400):
+        self.status_code = status.HTTP_400_BAD_REQUEST
+        super().__init__(detail, code)

--- a/tradingdb/restapi/exceptions.py
+++ b/tradingdb/restapi/exceptions.py
@@ -1,7 +1,8 @@
-from rest_framework.exceptions import APIException, status
+from rest_framework.exceptions import APIException
 
 
 class InvalidEthereumAddressForFilter(APIException):
     def __init__(self, detail, code=400):
-        self.status_code = status.HTTP_400_BAD_REQUEST
+        # Set the response `status_code`, override default 500 error
+        self.status_code = code
         super().__init__(detail, code)

--- a/tradingdb/restapi/filters.py
+++ b/tradingdb/restapi/filters.py
@@ -10,11 +10,11 @@ from tradingdb.relationaldb.models import (CentralizedOracle, Event, Market,
                                            Order, OutcomeTokenBalance)
 
 
-def normalize_address_or_raise(address: str):
+def normalize_address_or_raise(address: str, code: int = 400):
     try:
         return normalize_address_without_0x(address.strip())
     except Exception as e:
-        raise InvalidEthereumAddressForFilter("Invalid address {}".format(address)) from e
+        raise InvalidEthereumAddressForFilter("Invalid address {}".format(address), code=code) from e
 
 
 class DefaultPagination(LimitOffsetPagination):

--- a/tradingdb/restapi/filters.py
+++ b/tradingdb/restapi/filters.py
@@ -5,19 +5,16 @@ from django_eth_events.utils import normalize_address_without_0x
 from django_filters import rest_framework as filters
 from rest_framework.pagination import LimitOffsetPagination
 
+from .exceptions import InvalidEthereumAddressForFilter
 from tradingdb.relationaldb.models import (CentralizedOracle, Event, Market,
                                            Order, OutcomeTokenBalance)
-
-
-class InvalidEthereumAddressForFilter(Exception):
-    pass
 
 
 def normalize_address_or_raise(address: str):
     try:
         return normalize_address_without_0x(address.strip())
     except Exception as e:
-        raise InvalidEthereumAddressForFilter(address) from e
+        raise InvalidEthereumAddressForFilter("Invalid address {}".format(address)) from e
 
 
 class DefaultPagination(LimitOffsetPagination):

--- a/tradingdb/restapi/tests/test_views.py
+++ b/tradingdb/restapi/tests/test_views.py
@@ -148,6 +148,12 @@ class TestViews(APITestCase):
         response = self.client.get(url, content_type='application/json')
         self.assertEqual(len(response.json().get('results')), 0)
 
+        # Test with invalid, not ethereum compliant, collateral token
+        wrong_collateral_token = event.collateral_token[:-1]
+        url = reverse('api:markets') + '?collateral_token=%s' % wrong_collateral_token
+        response = self.client.get(url, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_market_trading_volume(self):
 
         # create markets

--- a/tradingdb/restapi/tests/test_views.py
+++ b/tradingdb/restapi/tests/test_views.py
@@ -106,6 +106,11 @@ class TestViews(APITestCase):
         response = self.client.get(url, content_type='application/json')
         self.assertEqual(len(response.json().get('results')), 2)
 
+        # Test with not valid address
+        url = reverse('api:markets') + '?creator=%s' % market.creator[:-1]
+        response = self.client.get(url, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_markets_by_resolution_date(self):
         # test empty events response
         empty_markets_response = self.client.get(reverse('api:markets'), content_type='application/json')


### PR DESCRIPTION
Raise 400 bad request instead of 500 error when a bad ethereum address is provided to filters.